### PR TITLE
Replace fxhash with rustc-hash (Fixes RUSTSEC-2025-0057)

### DIFF
--- a/springtime-di/Cargo.toml
+++ b/springtime-di/Cargo.toml
@@ -21,9 +21,9 @@ default = ["threadsafe", "derive"]
 [dependencies]
 derive_more = { version = "2.0.1", features = ["debug"] }
 futures = { version = "0.3.29", optional = true }
-fxhash = "0.2.1"
 inventory = "0.3.13"
 itertools = "0.14.0"
+rustc-hash = "2.1.1"
 springtime-di-derive = { path = "../springtime-di-derive", version = "0.3", optional = true, default-features = false }
 thiserror = "2.0.3"
 tracing = "0.1.40"

--- a/springtime-di/src/component_registry.rs
+++ b/springtime-di/src/component_registry.rs
@@ -20,10 +20,10 @@ use crate::instance_provider::{
 use derive_more::Debug;
 #[cfg(feature = "async")]
 use futures::future::BoxFuture;
-use fxhash::{FxHashMap, FxHashSet};
 use itertools::Itertools;
 #[cfg(test)]
 use mockall::automock;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::any::{type_name, TypeId};
 use thiserror::Error;
 
@@ -483,7 +483,7 @@ mod registry {
     use crate::component_registry::{
         ComponentAliasMetadata, ComponentDefinition, ComponentMetadata,
     };
-    use fxhash::{FxHashMap, FxHashSet};
+    use rustc_hash::{FxHashMap, FxHashSet};
     use std::any::TypeId;
     use tracing::debug;
 

--- a/springtime-di/src/factory.rs
+++ b/springtime-di/src/factory.rs
@@ -16,9 +16,9 @@ use crate::scope::{
 use futures::future::BoxFuture;
 #[cfg(feature = "async")]
 use futures::FutureExt;
-use fxhash::{FxHashMap, FxHashSet};
 #[cfg(not(feature = "async"))]
 use itertools::Itertools;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::any::TypeId;
 use tracing::debug;
 

--- a/springtime-di/src/scope.rs
+++ b/springtime-di/src/scope.rs
@@ -11,9 +11,9 @@
 
 use crate::component_registry::ComponentDefinition;
 use crate::instance_provider::ComponentInstanceAnyPtr;
-use fxhash::FxHashMap;
 #[cfg(test)]
 use mockall::automock;
+use rustc_hash::FxHashMap;
 use std::any::TypeId;
 
 #[cfg(not(feature = "threadsafe"))]

--- a/springtime-web-axum/Cargo.toml
+++ b/springtime-web-axum/Cargo.toml
@@ -20,7 +20,7 @@ axum = "0.8.1"
 config = "0.15.5"
 downcast = "0.11.0"
 futures = "0.3.31"
-fxhash = "0.2.1"
+rustc-hash = "2.1.1"
 serde = "1.0.217"
 springtime = { version = "1.0.0", path = "../springtime" }
 springtime-di = { version = "1.0.0", path = "../springtime-di", features = ["async"] }

--- a/springtime-web-axum/src/config.rs
+++ b/springtime-web-axum/src/config.rs
@@ -5,7 +5,7 @@
 //! by values from `springtime.json` file under the `web` key.
 
 use config::{Config, File};
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use springtime::config::CONFIG_FILE;
 use springtime::future::{BoxFuture, FutureExt};

--- a/springtime-web-axum/src/controller.rs
+++ b/springtime-web-axum/src/controller.rs
@@ -3,9 +3,9 @@
 
 use axum::Router;
 use downcast::{downcast_sync, AnySync};
-use fxhash::FxHashSet;
 #[cfg(test)]
 use mockall::automock;
+use rustc_hash::FxHashSet;
 use springtime_di::injectable;
 use springtime_di::instance_provider::{ComponentInstancePtr, ErrorPtr};
 

--- a/springtime-web-axum/src/router.rs
+++ b/springtime-web-axum/src/router.rs
@@ -76,7 +76,7 @@ mod tests {
     use crate::controller::MockController;
     use crate::router::{ControllerRouterBootstrap, MockRouterConfigure, RouterBootstrap};
     use axum::Router;
-    use fxhash::FxHashSet;
+    use rustc_hash::FxHashSet;
     use springtime_di::instance_provider::ComponentInstancePtr;
 
     #[test]


### PR DESCRIPTION
This PR resolves [RUSTSEC-2025-0057](https://rustsec.org/advisories/RUSTSEC-2025-0057.html).

According to https://github.com/rustsec/advisory-db/issues/2185#issue-2763303381 `rustc-hash` should be a drop-in replacement for `fxhash`.
